### PR TITLE
Add routing buttons on landing page

### DIFF
--- a/ipad-controller/src/App.css
+++ b/ipad-controller/src/App.css
@@ -1,5 +1,8 @@
+@import url(./sharedComponents/globals.css);
+
 .App {
   text-align: center;
+  color: var(--font-color);
 }
 
 .App-logo {

--- a/ipad-controller/src/modules/basket/components/RemoteToggle.tsx
+++ b/ipad-controller/src/modules/basket/components/RemoteToggle.tsx
@@ -1,6 +1,7 @@
 import React, { FormEventHandler, ReactNode } from "react";
 import styles from "./RemoteToggle.module.css";
-import moduleinfo from "../moduleinfo.json";
+import { useSelector } from "react-redux";
+import { RootState } from "../../../store";
 
 type CheckBoxButtonProps = {
   children?: ReactNode;
@@ -18,6 +19,8 @@ const RemoteCheckboxButton = ({
   // Decide name/id of toggle based on which property is defined
   id = id ? id : String.apply(children);
   children = children ? children : id;
+
+  const url = useSelector((state: RootState) => state.url);
 
   // Perform post with the new event. endpoint is defined in moduleinfo.json
   const handleToggleEvent: FormEventHandler<HTMLInputElement> = (event) => {
@@ -39,7 +42,7 @@ const RemoteCheckboxButton = ({
       }),
     };
 
-    fetch(moduleinfo.url, requestOptions)
+    fetch(url.value, requestOptions)
       .then((response) => {
         console.log(response);
         return response.json();

--- a/ipad-controller/src/modules/landing/Landing.module.css
+++ b/ipad-controller/src/modules/landing/Landing.module.css
@@ -1,0 +1,22 @@
+.urlWrapper {
+  margin: 5px;
+}
+
+.urlWrapper label input {
+  width: 300px;
+}
+
+.endpointsWrapper {
+  display: flex;
+  flex-direction: column;
+  margin: 10px;
+}
+
+.endpoints {
+  display: flex;
+}
+
+.endpoint button {
+  padding: 3px;
+  margin: 5px;
+}

--- a/ipad-controller/src/modules/landing/index.tsx
+++ b/ipad-controller/src/modules/landing/index.tsx
@@ -1,15 +1,17 @@
-import React, { useState, useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { setByValue } from '../../reducers/urlSlice';
-import { RootState } from '../../store';
-import moduleinfo from "../basket/moduleinfo.json";
-
+import React, { useState, useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+import { setByValue } from "../../reducers/urlSlice";
+import { RootState } from "../../store";
+import styles from "./Landing.module.css";
 
 const Landing = () => {
     const url = useSelector((state: RootState) => state.url);
     const dispatch = useDispatch();
 
-    const [urlOverride, setUrlOverride] = useState(moduleinfo.url);
+    const [urlOverride, setUrlOverride] = useState(url.value);
+
+    const endpoints = ["/basket"];
 
     useEffect(() => {
         console.log(url);
@@ -18,27 +20,40 @@ const Landing = () => {
     const onSubmit = () => {
         //console.log("onSubmit called");
         dispatch(setByValue(urlOverride));
-    }
+    };
 
     return (
-        <div >
-            <form>
-                <label >
-                    <div style={{ color: 'white' }}>
-                        Enter your override URL:
-                    </div>
+        <div>
+            <form className={styles.urlWrapper}>
+                <label>
+                    <div>Enter your override URL:</div>
                     <input
                         type="text"
                         value={urlOverride}
                         onChange={(e) => setUrlOverride(e.target.value)}
-                        style={{ width: '300px' }}
                     />
                 </label>
             </form>
-            <button type="button" onClick={onSubmit}>Submit</button>
+            <button type="button" onClick={onSubmit}>
+                Submit
+            </button>
             {/*<div style={{ color: 'white' }}>
                 <strong>urlSlice value: </strong>{url.value}
             </div>*/}
+            <div className={styles.endpointsWrapper}>
+                endpoints
+                <div className={styles.endpoints}></div>
+                {/* TODO: Ensure endpoint keeps state of override-url */}
+                {endpoints.map((endpoint) => (
+                    <Link
+                        className={styles.endpoint}
+                        to={endpoint}
+                        key={endpoint}
+                    >
+                        <button>{endpoint}</button>
+                    </Link>
+                ))}
+            </div>
         </div>
     );
 };

--- a/ipad-controller/src/reducers/urlSlice.ts
+++ b/ipad-controller/src/reducers/urlSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import moduleinfo from "../modules/basket/moduleinfo.json"
 
 /*
 Slice containing url for basket backend.
@@ -9,7 +10,7 @@ export interface UrlState {
 }
 
 const initialState: UrlState = {
-  value: "http://localhost:4000",
+  value: moduleinfo.url,
 };
 
 export const urlSlice = createSlice({


### PR DESCRIPTION
Added a button on landing page to `/basket`
Configuration made on landing page should now be preserved when navigating to one of the endpoints